### PR TITLE
Fix embedded demo video in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project is licensed under the terms of the MIT license. See [LICENSE.md](ht
 
 **Roblox is providing this plugin source as a reference implementation, and we encourage the community to extend and build upon this!**
 
-https://github.com/Roblox/roblox-blender-plugin/assets/66378309/4e889d87-c0fc-4af5-b974-9eb129d16364
+https://github.com/Roblox/roblox-blender-plugin/assets/66378309/ba8b1bd9-e431-409d-b336-9cb046e00886
 
 # INSTALLATION
 ## UNINSTALL OLD VERSION


### PR DESCRIPTION
Changing repository access from private to public breaks existing github asset links.
This replaces the demo video link on the readme page with a new one.