### PR TITLE
Use less common port to avoid port conflicts

### DIFF
--- a/lib/oauth2_client.py
+++ b/lib/oauth2_client.py
@@ -72,7 +72,7 @@ from contextlib import asynccontextmanager
 from time import time
 
 
-PORT = 8080
+PORT = 8181
 HOST = "localhost"
 RESPONSE_TYPE = "code"
 CODE_CHALLENGE_METHOD = "S256"


### PR DESCRIPTION
Currently, the plugin uses port 8080 to start its localhost server listening for the oauth2 login callback.
This is a very common port used for alternative HTTP traffic. While the port selection makes sense, the fact that it's so common also raises the chance for conflicts with other applications.

This PR changes the port from 8080 to 8181, which is not a commonly used port but still resembles 8080 enough to indicate to a reader that it's used for http traffic.

[This Wikipedia article](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers) has a nice list of commonly used port numbers to avoid, and it does not list 8181 as common.

This should help avoid issues like https://github.com/Roblox/roblox-blender-plugin/issues/12