### PR TITLE
Require `https`, expect Roblox issuer to be secure

### DIFF
--- a/lib/jwt_http_client.py
+++ b/lib/jwt_http_client.py
@@ -49,7 +49,7 @@ class JWTHTTPClient(HTTPClient):
         :return: The JSON data as a dictionary.
         :raise JWTHTTPFetchError: If there's a problem fetching or decoding the data.
         """
-        if not (url.startswith("https://") or url.startswith("http://")):
+        if not url.startswith("https://"):
             raise JWTHTTPFetchError("Unsupported protocol in 'iss'")
 
         try:


### PR DESCRIPTION
Fixes https://github.com/Roblox/roblox-blender-plugin/issues/24