### PR TITLE
Fix uploading in 4.0

### DIFF
--- a/lib/get_selected_objects.py
+++ b/lib/get_selected_objects.py
@@ -61,17 +61,21 @@ def get_selected_objects(context):
         if area == current_area:
             continue
         if area.type == "OUTLINER" or area.type == "VIEW_3D":
-            # Temporary context override requires Blender version >= 3.2.0
-            with context.temp_override(area=area):
-                for selected_object in context.selected_ids:
-                    # Avoid double-counting objects that are selected in multiple outliners
-                    if selected_object in objects:
-                        continue
+            for region in area.regions:
+                if region.type == "WINDOW":
+                    # Temporary context override requires Blender version >= 3.2.0
+                    with context.temp_override(area=area, region=region):
+                        for selected_object in context.selected_ids:
+                            # Avoid double-counting objects that are selected in multiple outliners
+                            if selected_object in objects:
+                                continue
 
-                    # Avoid counting objects that can't be uploaded (Open Cloud servers require a mesh inside the asset)
-                    if not (__is_uploadable_object(selected_object) or __contains_uploadable_object(selected_object)):
-                        continue
+                            # Avoid counting objects that can't be uploaded (Open Cloud servers require a mesh inside the asset)
+                            if not (
+                                __is_uploadable_object(selected_object) or __contains_uploadable_object(selected_object)
+                            ):
+                                continue
 
-                    objects.append(selected_object)
+                            objects.append(selected_object)
 
     return objects


### PR DESCRIPTION
As of Blender [b82f3e90ca](  https://projects.blender.org/blender/blender/commit/b82f3e90caeb36d143eea090207b33a1d9b3bcf3) temporarily overriding context requires both the area and the region to behave correctly. We had not been accounting for this, meaning the plugin did not work in 4.0. This issue is now resolved.

Resolves:

https://github.com/Roblox/roblox-blender-plugin/issues/33