### PR TITLE
Support necessary export settings to import dynamic heads

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -147,9 +147,30 @@ class RbxAddonPreferences(AddonPreferences):
         soft_max=10.0,
         default=1.0,  # default: min slope: 0.005, max frame step: 10.
     )
+    add_leaf_bones: BoolProperty(
+        name="Add Leaf Bones",
+        description="Append a final bone to the end of each chain to specify last bone length (use this when you intend to edit the armature from exported data)",
+        default=True,
+    )
+    use_custom_props: BoolProperty(
+        name="Custom Properties",
+        description="Export Custom Properties",
+        default=True,
+    )
 
     def draw(self, context):
-        self.layout.prop(self, "export_scale")
+        self.layout.label(text="Include")
+        include_box = self.layout.box()
+        include_box.prop(self, "use_custom_props")
+
+        self.layout.label(text="Transform")
+        transform_box = self.layout.box()
+        transform_box.prop(self, "export_scale")
+
+        self.layout.label(text="Armature")
+        armature_box = self.layout.box()
+        armature_box.prop(self, "add_leaf_bones")
+
         self.layout.prop(self, "bake_anim", text="Bake Animation")
         bake_anim_box = self.layout.box()
         bake_anim_box.use_property_split = True

--- a/lib/export_fbx.py
+++ b/lib/export_fbx.py
@@ -73,6 +73,8 @@ def export_fbx(scene, view_layer, target_object, exported_file_path, preferences
             path_mode="COPY",
             embed_textures=True,
             use_active_collection=True,
+            add_leaf_bones=preferences.add_leaf_bones,
+            use_custom_props=preferences.use_custom_props,
         )
     finally:
         # Return to the previous active LayerCollection

--- a/lib/get_selected_objects.py
+++ b/lib/get_selected_objects.py
@@ -61,17 +61,21 @@ def get_selected_objects(context):
         if area == current_area:
             continue
         if area.type == "OUTLINER" or area.type == "VIEW_3D":
-            # Temporary context override requires Blender version >= 3.2.0
-            with context.temp_override(area=area):
-                for selected_object in context.selected_ids:
-                    # Avoid double-counting objects that are selected in multiple outliners
-                    if selected_object in objects:
-                        continue
+            for region in area.regions:
+                if region.type == "WINDOW":
+                    # Temporary context override requires Blender version >= 3.2.0
+                    with context.temp_override(area=area, region=region):
+                        for selected_object in context.selected_ids:
+                            # Avoid double-counting objects that are selected in multiple outliners
+                            if selected_object in objects:
+                                continue
 
-                    # Avoid counting objects that can't be uploaded (Open Cloud servers require a mesh inside the asset)
-                    if not (__is_uploadable_object(selected_object) or __contains_uploadable_object(selected_object)):
-                        continue
+                            # Avoid counting objects that can't be uploaded (Open Cloud servers require a mesh inside the asset)
+                            if not (
+                                __is_uploadable_object(selected_object) or __contains_uploadable_object(selected_object)
+                            ):
+                                continue
 
-                    objects.append(selected_object)
+                            objects.append(selected_object)
 
     return objects


### PR DESCRIPTION
Dynamic heads require the FBX is exported with add_leaf_bones=False and include_custom_properties=True. This PR introduces these settings to the add on preferences page so they can be configured to support dynamic head uploading via the plugin. 

For reference: https://create.roblox.com/docs/art/characters/creating/exporting-character