### PR TITLE
Add recommended vscode extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+        "jacqueslucke.blender-development",
+        "ms-python.black-formatter",
+        "ms-python.debugpy",
+        "ms-python.isort",
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+    ]
+}


### PR DESCRIPTION
Adding recommended extensions allows VS Code to prompt the developer to install extensions when opening the project, making it easier to dive into the code base without wondering if you've got what you need.