### PR TITLE
Sanitize exported file names to fix error during export

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+        "jacqueslucke.blender-development",
+        "ms-python.black-formatter",
+        "ms-python.debugpy",
+        "ms-python.isort",
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+    ]
+}

--- a/lib/upload_operator.py
+++ b/lib/upload_operator.py
@@ -150,7 +150,9 @@ class RBX_OT_upload(Operator):
 
             add_on_preferences = get_add_on_preferences(preferences)
             temporary_directory = TemporaryDirectory()
-            sanitized_object_name = "".join(c for c in target_object.name if c.isalnum() or c in (' ','.','_')).rstrip()
+            sanitized_object_name = "".join(
+                c for c in target_object.name if c.isalnum() or c in (" ", ".", "_")
+            ).rstrip()
             exported_file_path = Path(temporary_directory.name) / f"exported_{sanitized_object_name}.fbx"
             from .export_fbx import export_fbx
 

--- a/lib/upload_operator.py
+++ b/lib/upload_operator.py
@@ -150,7 +150,8 @@ class RBX_OT_upload(Operator):
 
             add_on_preferences = get_add_on_preferences(preferences)
             temporary_directory = TemporaryDirectory()
-            exported_file_path = Path(temporary_directory.name) / f"{target_object.name}.fbx"
+            sanitized_object_name = "".join(c for c in target_object.name if c.isalnum() or c in (' ','.','_')).rstrip()
+            exported_file_path = Path(temporary_directory.name) / f"exported_{sanitized_object_name}.fbx"
             from .export_fbx import export_fbx
 
             export_fbx(scene, view_layer, target_object, exported_file_path, add_on_preferences)


### PR DESCRIPTION
Fixes https://github.com/Roblox/roblox-blender-plugin/issues/67 where Blender allows object names to contain characters considered to be invalid for a file name by the operating system. Since this add-on uses the object name as the file name, an error occurs during export.

This PR fixes the problem by "sanitizing" (removing) any characters that are not `isalnum()` or in a set of other allowed characters ` `, `.`, and `_`.

Since this could result in an empty file name for objects that only contain invalid characters in their name, the file is also prefixed with `exported_` to ensure it has a valid file name.