### PR TITLE
Fix error catching in str_to_int()

### DIFF
--- a/lib/str_to_int.py
+++ b/lib/str_to_int.py
@@ -24,5 +24,5 @@ def str_to_int(string, *, default=None):
     otherwise returns default"""
     try:
         return int(string)
-    except TypeError:
+    except ValueError:
         return default


### PR DESCRIPTION
int() throws a ValueError, not a TypeError. If the add-on reads an unparsable value from the custom property, it currently errors out and gets soft locked because it doesn't catch the right exception.

This PR fixes that so it catches the exception being thrown correctly.