### PR TITLE
Update README outdated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://github.com/Roblox/roblox-blender-plugin/assets/66378309/ba8b1bd9-e431-40
 4. Restart Blender after uninstalling
 
 ## INSTALL NEW VERSION
-Prerequisite: Blender version 3.2 or greater is required
+Prerequisite: Blender version 4.4 or greater is required
 
 1. Be sure to [uninstall any old version](#uninstall-old-version) first, including restarting Blender afterward
 2. Download the latest add-on zip file from the [repository releases page](https://github.com/Roblox/roblox-blender-plugin/releases)


### PR DESCRIPTION
Newer blender versions have updated UI. Installation instructions in the README needed updating to match newer copy in Blender.