### PR TITLE
Use SelectorEventLoop on Windows due to aiodns incompatibility with ProactorEventLoop

### DIFF
--- a/lib/event_loop.py
+++ b/lib/event_loop.py
@@ -20,6 +20,12 @@
 
 import bpy
 import asyncio
+import platform
+
+if platform.system() == "Windows":
+    # aiodns is incompatible with ProactorEventLoop on Windows in some cases.
+    # https://github.com/aio-libs/aiodns?tab=readme-ov-file#note-for-windows-users
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 loop = asyncio.new_event_loop()
 timer_running = False


### PR DESCRIPTION
aiodns is incompatible with ProactorEventLoop in some cases, as noted [on their readme](https://github.com/aio-libs/aiodns?tab=readme-ov-file#note-for-windows-users).

The fix in this PR is to specify use of a SelectorEventLoop for windows users, as recommended by various issue threads on the topic.

This PR is being made in an attempt to fix https://github.com/Roblox/roblox-blender-plugin/issues/82