### PR TITLE
Fix error keys being shown instead of error messages

### DIFF
--- a/lib/request_login_details.py
+++ b/lib/request_login_details.py
@@ -195,5 +195,5 @@ async def __request_group_names_for_group_ids(group_ids):
                 return {str(group_data["id"]): group_data["name"] for group_data in response_data["data"]}
             except aiohttp.ClientResponseError as exception:
                 for error in response_data.get("errors", []):
-                    exception.message += f"{error['userFacingMessage']}\n"
+                    exception.message += f"{error.get('userFacingMessage', '')}\n"
                 raise exception

--- a/lib/request_login_details.py
+++ b/lib/request_login_details.py
@@ -195,5 +195,7 @@ async def __request_group_names_for_group_ids(group_ids):
                 return {str(group_data["id"]): group_data["name"] for group_data in response_data["data"]}
             except aiohttp.ClientResponseError as exception:
                 for error in response_data.get("errors", []):
-                    exception.message += f"{error.get('userFacingMessage', '')}\n"
+                    msg = error.get("userFacingMessage")
+                    if msg:
+                        exception.message += f"{msg}\n"
                 raise exception


### PR DESCRIPTION
This fix changes uses .get() to safely access values from a dictionary and check if that value exists before adding it to exception.message. Before, if the value didn't exist, the error name would be displayed. Now, if the error doesn't exist, don't add anything at all.

Related to #81 