### PR TITLE
fix: Modification of dictionary returned by locals()

### DIFF
--- a/dependencies_private/openapi_client/api/asset_api.py
+++ b/dependencies_private/openapi_client/api/asset_api.py
@@ -261,7 +261,11 @@ class AssetApi(object):
         :rtype: tuple(RobloxLongrunningOperation, status_code(int), headers(HTTPHeaderDict))
         """
 
-        local_var_params = locals()
+        local_var_params = {
+            'asset_id': asset_id,
+            'file_content': file_content,
+            'kwargs': kwargs
+        }
 
         all_params = [
             'asset_id',

--- a/dependencies_private/openapi_client/api/multipart_upload_api.py
+++ b/dependencies_private/openapi_client/api/multipart_upload_api.py
@@ -657,7 +657,12 @@ class MultipartUploadApi(object):
         :rtype: tuple(RobloxAssetsManagementAssetsUploadApiMultipartUploadStartResponse, status_code(int), headers(HTTPHeaderDict))
         """
 
-        local_var_params = locals()
+        local_var_params = {
+            'self': self,
+            'asset_id': asset_id,
+            'roblox_assets_management_assets_upload_api_multipart_upload_start_request': roblox_assets_management_assets_upload_api_multipart_upload_start_request,
+            'kwargs': kwargs
+        }
 
         all_params = [
             'asset_id',

--- a/dependencies_private/openapi_client/api/upload_status_api.py
+++ b/dependencies_private/openapi_client/api/upload_status_api.py
@@ -235,7 +235,10 @@ class UploadStatusApi(object):
         :rtype: tuple(RobloxAssetsManagementAssetsUploadApiGetUploadStatusResponse, status_code(int), headers(HTTPHeaderDict))
         """
 
-        local_var_params = locals()
+        local_var_params = {
+            'operation_id': operation_id,
+            'kwargs': kwargs
+        }
 
         all_params = [
             'operation_id'
@@ -252,7 +255,7 @@ class UploadStatusApi(object):
             ]
         )
 
-        for key, val in six.iteritems(local_var_params['kwargs']):
+        for key, val in six.iteritems(kwargs):
             if key not in all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"

--- a/lib/auth_callback_request_handler.py
+++ b/lib/auth_callback_request_handler.py
@@ -104,31 +104,31 @@ class AuthCallbackRequestHandler:
             event.exception = exception
             return self.__get_error_response(
                 500,
-                f"Error: No authentication code received.\n{str(exception)}",
+                "Error: No authentication code received.",
             )
         except json.JSONDecodeError as exception:
             event.exception = exception
             return self.__get_error_response(
                 500,
-                f"Error: Server's response was not valid JSON.\n{str(exception)}\n{exception.doc}",
+                "Error: Server response was invalid.",
             )
         except aiohttp.ClientResponseError as exception:
             event.exception = exception
             return self.__get_error_response(
                 exception.status,
-                f"Error: Login request failed.\n{str(exception)}",
+                "Error: Login request failed.",
             )
         except aiohttp.ClientError as exception:
             event.exception = exception
             return self.__get_error_response(
                 500,
-                f"Login request failed.\n{str(exception)}",
+                "Login request failed.",
             )
         except Exception as exception:
             event.exception = exception
             return self.__get_error_response(
                 500,
-                f"Internal client error.\n{str(exception)}",
+                "Internal client error.",
             )
         finally:
             # Fire the event to let the login function resume


### PR DESCRIPTION
The dictionary returned by `locals()` is not a view of the function's locals, but a copy. Therefore, modification of the dictionary returned from `locals()` will not modify the local variables of the function. rather than assigning to the variable `z` directly, the dictionary returned by `locals()` is modified.

```

def modifies_locals_sum(x, y):
    locals()['z'] = x + y
    return z

def fixed_sum(x, y):
    z = x + y
    return z
```


fix approach: stop using `locals()` as a mutable working dictionary. Instead, create a normal dictionary with explicit entries for required args and kwargs, validate incoming kwargs against `all_params`, merge allowed kwargs into the dict, and then remove `kwargs` from that dict.

Best minimal fix in this file/region:
- In `dependencies_private/openapi_client/api/upload_status_api.py`, replace:
  - `local_var_params = locals()`
  - loop over `local_var_params['kwargs']`
  - `del local_var_params['kwargs']`
- with:
  - `local_var_params = {'operation_id': operation_id, 'kwargs': kwargs}`
  - loop over `kwargs`
  - delete `kwargs` key from `local_var_params` once merged.


### References
[The for statement](http://docs.python.org/2/reference/compound_stmts.html#the-for-statement)
[for statements](http://docs.python.org/2/tutorial/controlflow.html#for-statements)